### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/fardjad/node-parse-my-command.git"
+    "url": "git+https://github.com/fardjad/node-parse-my-command.git"
   },
   "license": "MIT",
   "author": "Fardjad Davari <public@fardjad.com>",


### PR DESCRIPTION
## Summary
- replace the SSH-only repository URL with a public HTTPS Git URL
- keep npm repository metadata usable without GitHub SSH credentials

## Verification
- TypeScript typecheck passed with the repository's Bun type definitions
- direct package metadata assertion passed
- `git diff --check`

The repository uses Bun for unit tests, builds, and Biome. Bun is unavailable in this Windows environment, and the local Biome scan sees CRLF differences across all checked-out files. Repository CI is the authoritative Bun/Linux validation for this metadata-only change.